### PR TITLE
feat: create common compose for 3 services

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,22 @@
+# Create .env file in root directory with following details
+
+# Environment
+NODE_ENV=development
+
+# Database Variables
+MYSQL_HOST=host # Use -> database (Name of the database service in Docker Compose)
+MYSQL_ROOT_PASSWORD=dbrootpassword # Database Root Password
+MYSQL_DATABASE=dbname # Database Name
+MYSQL_USER=dbuser # Database User
+MYSQL_PASSWORD=dbuserpassword # Database User Password
+MYSQL_HOST_PORT=port # Database Host Port (your computer) eg. 3307
+MYSQL_PORT=port # Port in the container eg. 3306
+MOUNT_VOLUME="/path/to/your/local/mount/folder" # Mount Volume for persisting DB Data
+
+# Backend Variables
+APP_HOST_PORT=port # Backend Host Port (your computer) eg. 3000
+APP_PORT=port # Port in the container eg. 3000 (usually same as APP_HOST_PORT)
+
+# React Frontend Variables
+REACT_APP_HOST_PORT=port # Frontend Host Port (your computer) eg. 5000
+REACT_APP_PORT=port # Port in the container eg. 5000 (usually same as REACT_APP_HOST_PORT)

--- a/backend/db/database.js
+++ b/backend/db/database.js
@@ -1,15 +1,16 @@
-require("dotenv").config();
+// Load environment variables from project root
+require("dotenv").config({ path: __dirname+'/../../.env' });
 
 // Get the client
 const mysql = require("mysql2/promise");
 
 // Create the connection to database
 const database = mysql.createPool({
-  host: process.env.DB_HOST, // address of the server
-  port: process.env.DB_PORT, // port of the DB server (mysql), not to be confused with the APP_PORT !
-  database: process.env.DB_NAME,
-  user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
+  host: process.env.MYSQL_HOST, // Service name of DB in docker-compose
+  port: process.env.MYSQL_PORT, // Port inside the container NOT HOST PORT for ACCESS.
+  database: process.env.MYSQL_DATABASE,
+  user: process.env.MYSQL_USER,
+  password: process.env.MYSQL_PASSWORD,
 });
 
 database

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,5 @@
 const app = require("./src/app");
-require("dotenv").config();
+require("dotenv").config({ path: "../.env" });
 const port = process.env.APP_PORT || 3000;
 
 // Listen for server events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,46 @@
 services:
+  database:
+    image: mysql
+    restart: always
+    environment:
+      MYSQL_HOST: ${MYSQL_HOST}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - ${MYSQL_HOST_PORT}:${MYSQL_PORT}
+    volumes:
+      - ${MOUNT_VOLUME}:/var/lib/mysql
+    healthcheck:
+      test: mysql -h 127.0.0.1 -u ${MYSQL_USER} -p${MYSQL_PASSWORD} -e "SELECT 1"
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   backend:
     build: ./backend
     ports:
-      - "3000:3000"
+      - ${APP_HOST_PORT}:${APP_PORT}
     volumes:
       - ./backend:/app  # Bind Mount pour tenez au courant le conteneur avec les changements local
       - /app/node_modules  # Named Mount pour ne pas toucher les node_modules de conteneur
     environment:
-      NODE_ENV: development
+      NODE_ENV: ${NODE_ENV}
+    env_file:
+      - .env # Specify this so it is available within the container
+    depends_on:
+      database:
+        condition: service_healthy
   
   frontend-react:
     build: ./frontend-react
     ports:
-      - "5000:5000"
+      - ${REACT_APP_HOST_PORT}:${REACT_APP_PORT}
     volumes:
       - ./frontend-react:/app  # Bind Mount pour tenez au courant le conteneur avec les changements local
       - /app/node_modules  # Named Mount pour ne pas toucher les node_modules de conteneur
     depends_on:
       - backend
+    env_file:
+      - .env # Specify this so it is available within the container


### PR DESCRIPTION
1. Add Database service in Docker-Compose
2. Add waiting logic for DB to be ready before starting backend
3. Add common ENV file in project root for all services
4. Add mechanism to access ENV file using path config in dotenv
5. Create sample ENV for reference